### PR TITLE
Remove double quotes from boundary

### DIFF
--- a/mjpeg-proxy.js
+++ b/mjpeg-proxy.js
@@ -33,7 +33,7 @@ function extractBoundary(contentType) {
       endIndex = contentType.length;
     }
   }
-  return contentType.substring(startIndex + 9, endIndex);
+  return contentType.substring(startIndex + 9, endIndex).replace(/"/gi,'');
 }
 
 var MjpegProxy = exports.MjpegProxy = function(mjpegUrl) {


### PR DESCRIPTION
On safari iphone and mac the stream freezes if in boundary value are present " (double quotes) chars
For example all avtech dvr server are affected by this issue
