### PR TITLE
Adjusting example

### DIFF
--- a/example/express-app.js
+++ b/example/express-app.js
@@ -19,22 +19,20 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var MjpegProxy = require('mjpeg-proxy').MjpegProxy;
 var express = require('express');
-var MjpegProxy = require('../mjpeg-proxy').MjpegProxy;
+var app = express();
+var HTTP_PORT = 8080;
 
 var cam1 = "http://admin:admin@192.168.124.54/cgi/mjpg/mjpg.cgi";
 var cam2 = "http://admin:@192.168.124.32/videostream.cgi";
 
-var app = express();
-
 app.set("view options", {layout: false});
 app.use(express.static(__dirname + '/public'));
-
-app.get('/', function(req, res) {
-  res.render('index.html');
-});
 
 app.get('/index1.jpg', new MjpegProxy(cam1).proxyRequest);
 app.get('/index2.jpg', new MjpegProxy(cam2).proxyRequest);
 
-app.listen(8080)
+app.listen(HTTP_PORT);
+
+console.log("Listening on port "+HTTP_PORT);


### PR DESCRIPTION
app.get('/', function(req, res) {
  res.render('index.html');
}); 

is not needed because 

app.use(express.static(__dirname + '/public'));

allow reading any file from /public folder
