### PR TITLE
Ignore two leading dashes from extracted boundary string

### DIFF
--- a/mjpeg-proxy.js
+++ b/mjpeg-proxy.js
@@ -33,7 +33,7 @@ function extractBoundary(contentType) {
       endIndex = contentType.length;
     }
   }
-  return contentType.substring(startIndex + 9, endIndex).replace(/"/gi,'');
+  return contentType.substring(startIndex + 9, endIndex).replace(/"/gi,'').replace(/^\-\-/gi, '');
 }
 
 var MjpegProxy = exports.MjpegProxy = function(mjpegUrl) {


### PR DESCRIPTION
Some cameras returns "bad" boundary in HTTP header (with leading two dashes). Ignore them when doing boundary extraction.

eg.: http://75.129.81.154/nphMotionJpeg?Resolution=640x480&Quality=Standard

HTTP/1.0 200 OK
Content-type: multipart/x-mixed-replace; boundary=--myboundary

--myboundary
Content-length: 30427
Content-type: image/jpeg

[...jpeg frame content...]
