### PR TITLE
Update buffertools version

### DIFF
--- a/mjpeg-proxy.js
+++ b/mjpeg-proxy.js
@@ -22,7 +22,7 @@
 var url = require('url');
 var http = require('http');
 
-require('buffertools');
+var buffertools = require('buffertools');
 
 function extractBoundary(contentType) {
   var startIndex = contentType.indexOf('boundary=');
@@ -70,7 +70,7 @@ var MjpegProxy = exports.MjpegProxy = function(mjpegUrl) {
           // Fix CRLF issue on iOS 6+: boundary should be preceded by CRLF.
           if (lastByte1 != null && lastByte2 != null) {
             var oldheader = '--' + self.boundary;
-            var p = chunk.indexOf(oldheader); // indexOf provided by buffertools
+            var p = buffertools.indexOf(chunk, oldheader);
 
             if (p == 0 && !(lastByte2 == 0x0d && lastByte1 == 0x0a) || p > 1 && !(chunk[p - 2] == 0x0d && chunk[p - 1] == 0x0a)) {
               var b1 = chunk.slice(0, p);
@@ -88,7 +88,7 @@ var MjpegProxy = exports.MjpegProxy = function(mjpegUrl) {
 
             // First time we push data... lets start at a boundary
             if (self.newAudienceResponses.indexOf(res) >= 0) {
-              var p = chunk.indexOf('--' + self.boundary); // indexOf provided by buffertools
+              var p = buffertools.indexOf(chunk, '--' + self.boundary);
               if (p >= 0) {
                 res.write(chunk.slice(p));
                 self.newAudienceResponses.splice(self.newAudienceResponses.indexOf(res), 1); // remove from new

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./mjpeg-proxy",
   "dependencies": {
-    "buffertools": "1.1.x"
+    "buffertools": "^2.1.2"
   },
   "devDependencies": {
     "express": "3.1.x"


### PR DESCRIPTION
buffertools 1.1.x is incompatible with node versions greater than 0.10.x. Updating version allows for compatibility with node 0.12.x+.

This PR may not be 100% ready for merging, will update when ready.

npm package should be updated after merging.