### PR TITLE
Remove whitespace from boundary string before extraction

### DIFF
--- a/mjpeg-proxy.js
+++ b/mjpeg-proxy.js
@@ -25,6 +25,8 @@ var http = require('http');
 var buffertools = require('buffertools');
 
 function extractBoundary(contentType) {
+  contentType = contentType.replace(/\s+/g, '');
+
   var startIndex = contentType.indexOf('boundary=');
   var endIndex = contentType.indexOf(';', startIndex);
   if (endIndex == -1) { //boundary is the last option


### PR DESCRIPTION
Panasonic BL-VT164P cameras use header formatted as such:

    multipart/x-mixed-replace;boundary =--myboundary

The extra whitespace throws off the ``extractBoundary`` parsing algorithm. By removing any whitespace from the string before parsing, the issue is eliminated.