### PR TITLE
Add Basic CORS Headers

### DIFF
--- a/mjpeg-proxy.js
+++ b/mjpeg-proxy.js
@@ -128,7 +128,9 @@ var MjpegProxy = exports.MjpegProxy = function(mjpegUrl) {
       'Expires': 'Mon, 01 Jul 1980 00:00:00 GMT',
       'Cache-Control': 'no-cache, no-store, must-revalidate',
       'Pragma': 'no-cache',
-      'Content-Type': 'multipart/x-mixed-replace;boundary=' + self.boundary
+      'Content-Type': 'multipart/x-mixed-replace;boundary=' + self.boundary,
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept'
     });
 
     self.audienceResponses.push(res);


### PR DESCRIPTION
Adds basic headers to allow cross origin usage of the mjpeg stream. These headers are required when interacting with the stream using canvas or webgl.

It's easy to add these headers in express, but this seems like a common enough use case that the proxy server itself should do this automatically.