### PR TITLE
Remove buffertools dependency

### DIFF
--- a/mjpeg-proxy.js
+++ b/mjpeg-proxy.js
@@ -22,8 +22,6 @@
 var url = require('url');
 var http = require('http');
 
-var buffertools = require('buffertools');
-
 function extractBoundary(contentType) {
   contentType = contentType.replace(/\s+/g, '');
 
@@ -76,7 +74,7 @@ var MjpegProxy = exports.MjpegProxy = function(mjpegUrl) {
           // Fix CRLF issue on iOS 6+: boundary should be preceded by CRLF.
           if (lastByte1 != null && lastByte2 != null) {
             var oldheader = '--' + self.boundary;
-            var p = buffertools.indexOf(chunk, oldheader);
+            var p = chunk.indexOf(oldheader);
 
             if (p == 0 && !(lastByte2 == 0x0d && lastByte1 == 0x0a) || p > 1 && !(chunk[p - 2] == 0x0d && chunk[p - 1] == 0x0a)) {
               var b1 = chunk.slice(0, p);
@@ -94,7 +92,7 @@ var MjpegProxy = exports.MjpegProxy = function(mjpegUrl) {
 
             // First time we push data... lets start at a boundary
             if (self.newAudienceResponses.indexOf(res) >= 0) {
-              var p = buffertools.indexOf(chunk, '--' + self.boundary);
+              var p = chunk.indexOf('--' + self.boundary);
               if (p >= 0) {
                 res.write(chunk.slice(p));
                 self.newAudienceResponses.splice(self.newAudienceResponses.indexOf(res), 1); // remove from new

--- a/package.json
+++ b/package.json
@@ -13,13 +13,10 @@
     "url": "git://github.com/legege/node-mjpeg-proxy.git"
   },
   "main": "./mjpeg-proxy",
-  "dependencies": {
-    "buffertools": "^2.1.2"
-  },
   "devDependencies": {
     "express": "3.1.x"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=1.5.0"
   }
 }


### PR DESCRIPTION
The `buffertools` module is no longer maintained and doesn't work with newer versions of Node.js. Most functionality is now available through the native Buffer class. This PR removes the buffertools dependency and uses native Buffer methods instead.

I've bumped the engines version to >=1.5.0 since that's when the indexOf function was introduced to the native Buffer class ([see history here](https://nodejs.org/api/buffer.html#buffer_buf_indexof_value_byteoffset_encoding))

The 'data' event provides a Buffer type ([docs here](https://nodejs.org/api/stream.html#stream_event_data)) which means we shouldn't need any of the indexOf changes from versions v4.4.0, v5.7.0, or v8.0.0 but I haven't tested this.